### PR TITLE
Replaced URI.escape deprecated in Ruby 2.7

### DIFF
--- a/lib/paypalhttp/serializers/form_encoded.rb
+++ b/lib/paypalhttp/serializers/form_encoded.rb
@@ -4,8 +4,8 @@ module PayPalHttp
   class FormEncoded
     def encode(request)
       encoded_params = []
-      request.body.each do |k, v|
-        encoded_params.push("#{URI.escape(k.to_s)}=#{URI.escape(v.to_s)}")
+      request.body.each do |key, val|
+        encoded_params.push("#{encode_part(key)}=#{encode_part(val)}")
       end
 
       encoded_params.join("&")
@@ -17,6 +17,12 @@ module PayPalHttp
 
     def content_type
       /^application\/x-www-form-urlencoded/
+    end
+
+    private
+    
+    def encode_part(part)
+      URI.encode_www_form_component(part.to_s)
     end
   end
 end


### PR DESCRIPTION
Replaced URI.escape with URI.encode_www_form_component to fix the deprecation warning in Ruby 2.7